### PR TITLE
Script to retrieve Plex Autoscan URL / Updated rclone version

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,7 +6,7 @@
   - name: "Get {{user}} gid"
     shell: "id -g {{user}}"
     register: gid
-      
+
   - name: Install common packages
     apt: "name={{item}} state=installed"
     with_items:
@@ -37,7 +37,7 @@
       - speedtest-cli
       - python-ndg-httpsclient
       - nethogs
-      
+
   - name: Install common pip modules
     pip: "name={{item}} state=latest"
     with_items:
@@ -91,9 +91,10 @@
       - /opt/scripts/nzb
       - /opt/scripts/nginx
       - /opt/scripts/plex
+      - /opt/scripts/plex_autoscan
       - "/home/{{user}}/.config/rclone"
       - "{{plex.transcodes}}"
-      
+
   - name: Check plexdrive mount folder exist
     stat:
       path: /mnt/plexdrive
@@ -111,6 +112,6 @@
 
   - name: Set /opt permissions
     shell: "chmod -R 775 /opt"
-    
+
   - name: Set /opt owner
     shell: "chown -R {{user}}:{{user}} /opt"

--- a/roles/scripts/tasks/main.yml
+++ b/roles/scripts/tasks/main.yml
@@ -10,7 +10,7 @@
     get_md5: false
     get_mime: false
   register: arrpush_script
-  
+
 - name: Import arrpush.sh
   template:
     src: arrpush.sh.js2
@@ -28,6 +28,15 @@
   template:
     src: revoke_certs.sh.js2
     dest: /opt/scripts/nginx/revoke_certs.sh
+    owner: "{{user}}"
+    group: "{{user}}"
+    mode: 0775
+    force: yes
+
+- name: Import plex_autoscan_url.sh
+  template:
+    src: plex_autoscan_url.sh.js2
+    dest: /opt/scripts/plex_autoscan/plex_autoscan_url.sh
     owner: "{{user}}"
     group: "{{user}}"
     mode: 0775

--- a/roles/scripts/templates/plex_autoscan_url.sh.js2
+++ b/roles/scripts/templates/plex_autoscan_url.sh.js2
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+domain={{domain}}
+port=$(cat /opt/plex_autoscan/config/config.json | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["'SERVER_PORT'"]';)
+token=$(grep -m 1 -oP '0.0.0.0:3468/\K.*' /opt/plex_autoscan/*.log)
+echo "Your Plex Autoscan URL:"
+echo "http://${domain}:${port}/${token}"

--- a/settings.yml
+++ b/settings.yml
@@ -14,7 +14,7 @@
   plex_autoscan:
     ip: "0.0.0.0"
   rclone:
-    version: 1.36
+    version: 1.38
   unionfs_cleaner:
     max_local_gigabytes: 200
     size_check_mins: 30


### PR DESCRIPTION
A quick way to get the Plex Autoscan URL.

```
$ ./plex_autoscan_url.sh
Your Plex Autoscan URL:
http://domain.com:3468/xxxx
```

***

Updated rclone version to 1.38 in settings.yml