### PR TITLE
NZBGet: now using the Suitarr image

### DIFF
--- a/roles/jackett/tasks/main.yml
+++ b/roles/jackett/tasks/main.yml
@@ -14,7 +14,7 @@
     env:
       APP: "jackett"
       VERSION: "unstable"
-      BACKUP: "yes"
+      BACKUP: "no"
       PUID: "{{uid.stdout}}"
       PGID: "{{gid.stdout}}"
       VIRTUAL_HOST: "jackett.{{domain}}"

--- a/roles/nzbget/tasks/main.yml
+++ b/roles/nzbget/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: "Get {{user}} gid"
   shell: "id -g {{user}}"
   register: gid
- 
+
 - name: Stop and remove any existing container
   docker_container:
     name: nzbget
@@ -20,7 +20,7 @@
 
 - name: "Set {{nzbget.downloads}} owner"
   shell: "chown -R {{user}}:{{user}} {{nzbget.downloads}}"
-  
+
 - name: Check nzbget.conf exists
   stat:
     path: "/opt/nzbget/nzbget.conf"
@@ -29,15 +29,18 @@
 - name: Create and start container
   docker_container:
     name: nzbget
-    image: linuxserver/nzbget
+    image: hotio/suitarr
     pull: yes
     published_ports:
-      - "127.0.0.1:6789:6789"
+      - "127.0.0.1:6789:8080"
     env:
+      APP: "nzbget"
+      VERSION: "unstable"
+      BACKUP: "no"
       PUID: "{{uid.stdout}}"
       PGID: "{{gid.stdout}}"
       VIRTUAL_HOST: "nzbget.{{domain}}"
-      VIRTUAL_PORT: 6789
+      VIRTUAL_PORT: 8080
       LETSENCRYPT_HOST: "nzbget.{{domain}}"
       LETSENCRYPT_EMAIL: "{{email}}"
     volumes:
@@ -124,5 +127,3 @@
     name: nzbget
     state: started
   when: nzbget_conf.stat.exists == False
-
-

--- a/roles/nzbhydra/tasks/main.yml
+++ b/roles/nzbhydra/tasks/main.yml
@@ -14,7 +14,7 @@
     env:
       APP: "nzbhydra"
       VERSION: "unstable"
-      BACKUP: "yes"
+      BACKUP: "no"
       PUID: "{{uid.stdout}}"
       PGID: "{{gid.stdout}}"
       VIRTUAL_HOST: "nzbhydra.{{domain}}"

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: "Get {{user}} gid"
   shell: "id -g {{user}}"
   register: gid
- 
+
 - name: Stop and remove any existing container
   docker_container:
     name: radarr
@@ -24,7 +24,7 @@
       VERSION: "unstable"
       PUID: "{{uid.stdout}}"
       PGID: "{{gid.stdout}}"
-      BACKUP: "yes"
+      BACKUP: "no"
       MONO_TLS_PROVIDER: legacy
       VIRTUAL_HOST: "radarr.{{domain}}"
       VIRTUAL_PORT: 8080

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: "Get {{user}} gid"
   shell: "id -g {{user}}"
   register: gid
- 
+
 - name: Stop and remove any existing container
   docker_container:
     name: sonarr
@@ -19,10 +19,10 @@
     pull: yes
     published_ports:
       - "127.0.0.1:8989:8080"
-    env:      
+    env:
       APP: "sonarr"
       VERSION: "unstable"
-      BACKUP: "yes"
+      BACKUP: "no"
       PUID: "{{uid.stdout}}"
       PGID: "{{gid.stdout}}"
       MONO_TLS_PROVIDER: legacy


### PR DESCRIPTION
- Switched to using the Suitarr image for NZBGet (this will require the address alias to be `nzbget:8080` for Sonarr and Radarr) 
- Turned off backups for all Suitarr related containers.