### PR TITLE
Backup task: Tweaked Pushover message to work during cron task

### DIFF
--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -19,7 +19,11 @@
     when: backup_lock.stat.exists == False
 
   - name: "Get Start Time"
-    set_fact: start_time="{{lookup('pipe','date \"+%s\"')}}"
+    shell: 'echo $(date +\%s)'
+    register: current_start_timestamp
+
+  - name: "Save Start Time"
+    set_fact: start_time="{{current_start_timestamp.stdout}}"
 
   - name: "Pushover Message: Started Cloudbox backup task."
     pushover:
@@ -272,19 +276,12 @@
         (backup.use_rsync == false)
       )
 
-  - name: "Get ansible-playbook binary path"
-    shell: "which ansible-playbook"
-    register: playbook_binary
-
-  - name: "Schedule cron backup for state: {{backup.cron_state}}, when: {{backup.cron_time}}"
-    cron:
-      name: "Backup Cloudbox"
-      special_time: "{{backup.cron_time}}"
-      job: "{{playbook_binary.stdout}} {{playbook_dir}}/cloudbox.yml --tags backup"
-      state: "{{backup.cron_state}}"
-
   - name: "Get End Time"
-    set_fact: end_time="{{lookup('pipe','date \"+%s\"')}}"
+    shell: 'echo $(date +\%s)'
+    register: current_end_timestamp
+
+  - name: "Save End Time"
+    set_fact: end_time="{{current_end_timestamp.stdout}}"
 
   - name: "Pushover Message: Finished Cloudbox backup task in {{  ((((end_time|int) - (start_time|int)) /60)|int|abs) }} minutes."
     pushover:
@@ -304,6 +301,17 @@
         or
         (backup.pushover_user_key | trim == '')
       )
+
+  - name: "Get ansible-playbook binary path"
+    shell: "which ansible-playbook"
+    register: playbook_binary
+
+  - name: "Schedule cron backup for state: {{backup.cron_state}}, when: {{backup.cron_time}}"
+    cron:
+      name: "Backup Cloudbox"
+      special_time: "{{backup.cron_time}}"
+      job: "{{playbook_binary.stdout}} {{playbook_dir}}/cloudbox.yml --tags backup"
+      state: "{{backup.cron_state}}"
 
   always:
   - debug: msg="Finished backup"

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -18,12 +18,8 @@
       group: "{{user}}"
     when: backup_lock.stat.exists == False
 
-  - name: "Get Start Time"
-    shell: 'echo $(date +\%s)'
-    register: current_start_timestamp
-
   - name: "Save Start Time"
-    set_fact: start_time="{{current_start_timestamp.stdout}}"
+    set_fact: start_time="{{lookup('pipe','date \"+%s\"')}}"
 
   - name: "Pushover Message: Started Cloudbox backup task."
     pushover:
@@ -276,12 +272,8 @@
         (backup.use_rsync == false)
       )
 
-  - name: "Get End Time"
-    shell: 'echo $(date +\%s)'
-    register: current_end_timestamp
-
   - name: "Save End Time"
-    set_fact: end_time="{{current_end_timestamp.stdout}}"
+    set_fact: end_time="{{lookup('pipe','date \"+%s\"')}}"
 
   - name: "Pushover Message: Finished Cloudbox backup task in {{  ((((end_time|int) - (start_time|int)) /60)|int|abs) }} minutes."
     pushover:


### PR DESCRIPTION
- During a scheduled backup, the cron scheduler task prevented the Pushover message task below it from running. This was fixed by simply moving the Pushover message task above it.